### PR TITLE
If RepoTags is empty in the from image we did not set the command lin…

### DIFF
--- a/docker-copyedit.py
+++ b/docker-copyedit.py
@@ -718,8 +718,8 @@ def edit_datadir(datadir, out, edits):
                 replaced[config_filename] = new_config_filename
             else:
                 logg.info("  unchanged %s", config_filename)
-            #
-            if manifest[item]["RepoTags"]:
+            # if manifest[item]["RepoTags"]:    # False if exists but is empty
+            if "RepoTags" in manifest[item]:
                 manifest[item]["RepoTags"] = [out]
         manifest_text = cleans(json.dumps(manifest))
         manifest_filename = os.path.join(datadir, manifest_file)


### PR DESCRIPTION
If RepoTags is empty in the from image we did not set the command line provided tags in the target image and image just had a hash ID

This issue appeared to me when using podman instead of docker --docker=podman

The source image was tagged but the file generated from save had an empty array for RepoTags and therefore the
test resulted in the tags not getting set in the target.


